### PR TITLE
Modify deprecated parameters and attributes, minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Lastest Release](https://img.shields.io/badge/release-v0.1.1-green)
 [![PyPI Version](https://img.shields.io/pypi/v/linearboost)](https://pypi.org/project/linearboost/)
 ![Python Versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
-=======================
+
 
 LinearBoost is a fast and accurate classification algorithm built to enhance the performance of the linear classifier SEFR. It combines efficiency and accuracy, delivering state-of-the-art F1 scores and classification performance.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LinearBoost Classifier
 
-![Lastest Release](https://img.shields.io/badge/release-v0.1.0-green)
+![Lastest Release](https://img.shields.io/badge/release-v0.1.1-green)
 [![PyPI Version](https://img.shields.io/pypi/v/linearboost)](https://pypi.org/project/linearboost/)
 ![Python Versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
 =======================
@@ -64,7 +64,7 @@ The following parameters yielded optimal results during testing. All results are
   - `SAMME`: May be better for datasets with clearer separations between classes.
   - `SAMME.R`: Can handle more nuanced class probabilities.
 
-  **Note:** As of scikit-learn v1.6, the `algorithm` parameter is deprecated and will be removed in v1.8. LinearBoost will only implement the 'SAMME' algorithm in newer versions.
+  **Note:** As of scikit-learn v1.6, the `algorithm` parameter is deprecated and will be removed in v1.8. LinearBoostClassifier will only implement the 'SAMME' algorithm in newer versions.
 
 - **`scaler`**:  
   The following scaling methods are recommended based on dataset characteristics:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+# LinearBoost Classifier
 
-LinearBoost Classifier
+![Lastest Release](https://img.shields.io/badge/release-v0.1.0-green)
+[![PyPI Version](https://img.shields.io/pypi/v/linearboost)](https://pypi.org/project/linearboost/)
+![Python Versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
 =======================
 
 LinearBoost is a fast and accurate classification algorithm built to enhance the performance of the linear classifier SEFR. It combines efficiency and accuracy, delivering state-of-the-art F1 scores and classification performance.
@@ -23,17 +26,15 @@ Version 0.1.0 of **LinearBoost Classifier** is released, with a pull request fro
 - Both SEFR and LinearBoostClassifier classes are refactored to fully adhere to Scikit-learn's conventions and API. Now, they are standard Scikit-learn estimators that can be used in Scikit-learn pipelines, grid search, etc.
 - Added unit tests (using pytest) to ensure the estimators adhere to Scikit-learn conventions.
 - Added fit_intercept parameter to SEFR similar to other linear estimators in Scikit-learn (e.g., LogisticRegression, LinearRegression, etc.).
-- Removed random_state parameter from LinearBoostClassifier as it doesn't affect the result, since SEFR doesn't expose a random_state argument. According to Scikit-learn documentation for this parameter in AdaBoostClassifier:         it is only used when estimator exposes a random_state.
+- Removed random_state parameter from LinearBoostClassifier as it doesn't affect the result, since SEFR doesn't expose a random_state argument. According to Scikit-learn documentation for this parameter in AdaBoostClassifier: 
+  > it is only used when estimator exposes a random_state.
 - Added docstring to both SEFR and LinearBoostClassifier classes.
 - Used uv for project and package management.
 - Used ruff and isort for formatting and lining.
-- Added a GitHub workflow (.github/workflows/ci.yml) for CI on PRs.
-
+- Added a GitHub workflow (*.github/workflows/ci.yml*) for CI on PRs.
 
 
 ## 🚀 New Release (v0.0.5) 
-
-
 Version 0.0.5 of the **LinearBoost Classifier** is released! This new version introduces several exciting features and improvements:
 
 - 🛠️ Support of custom loss function
@@ -62,6 +63,8 @@ The following parameters yielded optimal results during testing. All results are
   Use either `SAMME` or `SAMME.R`. The choice depends on the specific problem:
   - `SAMME`: May be better for datasets with clearer separations between classes.
   - `SAMME.R`: Can handle more nuanced class probabilities.
+
+  **Note:** As of scikit-learn v1.6, the `algorithm` parameter is deprecated and will be removed in v1.8. LinearBoost will only implement the 'SAMME' algorithm in newer versions.
 
 - **`scaler`**:  
   The following scaling methods are recommended based on dataset characteristics:
@@ -148,11 +151,10 @@ params = {
     'enable_categorical': True,
     'eval_metric': 'logloss'
 }
-````
+```
 
 #### CatBoost
 ```python
-
 params = {
     'iterations': trial.suggest_int('iterations', 50, 500),
     'depth': trial.suggest_int('depth', 1, 16),
@@ -168,11 +170,10 @@ params = {
     'eval_metric': 'F1',
     'cat_features': categorical_cols
 }
-````
+```
 
 #### LightGBM
 ```python
-
 params = {
     'objective': 'binary',
     'metric': 'binary_logloss',
@@ -191,19 +192,17 @@ params = {
     'cat_l2': trial.suggest_loguniform('cat_l2', 1e-8, 10.0),
     'verbosity': -1
 }
-````
+```
 
 #### LinearBoost
 ```python
-
 params = {
     'n_estimators': trial.suggest_int('n_estimators', 10, 200),
     'learning_rate': trial.suggest_loguniform('learning_rate', 0.01, 1),
     'algorithm': trial.suggest_categorical('algorithm', ['SAMME', 'SAMME.R']),
     'scaler': trial.suggest_categorical('scaler', ['minmax', 'robust', 'quantile-uniform', 'quantile-normal'])
 }
-````
-
+```
 
 ### Why LinearBoost?
 LinearBoost's combination of **runtime efficiency** and **high accuracy** makes it a powerful choice for real-world machine learning tasks, particularly in resource-constrained or real-time applications.

--- a/src/linearboost/__init__.py
+++ b/src/linearboost/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from .linear_boost import LinearBoostClassifier
 from .sefr import SEFR

--- a/src/linearboost/linear_boost.py
+++ b/src/linearboost/linear_boost.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 from sklearn.utils import compute_sample_weight
-from sklearn.utils._param_validation import Interval, StrOptions, Hidden
+from sklearn.utils._param_validation import Hidden, Interval, StrOptions
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils.validation import check_is_fitted
 
@@ -143,15 +143,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
     estimator_errors_ : ndarray of floats
         Classification error for each estimator in the boosted
         ensemble.
-
-    feature_importances_ : ndarray of shape (n_features,)
-        The impurity-based feature importances if supported by the
-        ``estimator`` (when based on decision trees).
-
-        Warning: impurity-based feature importances can be misleading for
-        high cardinality features (many unique values). See
-        :func:`sklearn.inspection.permutation_importance` as an alternative.
-
+    
     n_features_in_ : int
         Number of features seen during :term:`fit`.
 
@@ -184,7 +176,10 @@ class LinearBoostClassifier(AdaBoostClassifier):
     _parameter_constraints: dict = {
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
-        "algorithm": [StrOptions({"SAMME", "SAMME.R"}), Hidden(StrOptions({"deprecated"}))],
+        "algorithm": [
+            StrOptions({"SAMME", "SAMME.R"}),
+            Hidden(StrOptions({"deprecated"})),
+        ],
         "scaler": [StrOptions({s for s in _scalers})],
         "class_weight": [
             StrOptions({"balanced_subsample", "balanced"}),

--- a/src/linearboost/linear_boost.py
+++ b/src/linearboost/linear_boost.py
@@ -204,7 +204,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
             estimator=SEFR(),
             n_estimators=n_estimators,
             learning_rate=learning_rate,
-            algorithm="deprecated" if SKLEARN_V1_6_OR_LATER else algorithm,
+            algorithm=algorithm,
         )
 
         self.scaler = scaler

--- a/src/linearboost/linear_boost.py
+++ b/src/linearboost/linear_boost.py
@@ -55,13 +55,13 @@ class LinearBoostClassifier(AdaBoostClassifier):
     n_estimators : int, default=200
         The maximum number of SEFR classifiers at which boosting is terminated.
         In case of perfect fit, the learning procedure is stopped early.
-        Values must be in the range `[1, inf)`, preferably in the range `[10, 200]`.
+        Values must be in the range `[1, inf)`, preferably `[10, 200]`.
 
     learning_rate : float, default=1.0
         Weight applied to each SEFR classifier at each boosting iteration. A higher
         learning rate increases the contribution of each SEFR classifier. There is
         a trade-off between the `learning_rate` and `n_estimators` parameters.
-        Values must be in the range `(0.0, inf)`, preferably in the range `(0.0, 1.0)`.
+        Values must be in the range `(0.0, inf)`, preferably `(0.0, 1.0)`.
 
     algorithm : {'SAMME', 'SAMME.R'}, default='SAMME'
         If 'SAMME' then use the SAMME discrete boosting algorithm.
@@ -156,7 +156,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
 
     Notes
     -----
-    The classifier only supports binary classification tasks.
+    This classifier only supports binary classification tasks.
 
     Examples
     --------

--- a/src/linearboost/linear_boost.py
+++ b/src/linearboost/linear_boost.py
@@ -75,7 +75,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
 
     scaler : str, default='minmax'
         Specifies the scaler to apply to the data. Options include:
-        
+
         - 'minmax': Applies MinMaxScaler.
         - 'quantile-uniform': Uses QuantileTransformer with `output_distribution='uniform'`.
         - 'quantile-normal': Uses QuantileTransformer with `output_distribution='normal'`.
@@ -112,7 +112,6 @@ class LinearBoostClassifier(AdaBoostClassifier):
         - y_true: Ground truth (correct) target values.
         - y_pred: Estimated target values.
         - sample_weight: Sample weights.
-
 
     Attributes
     ----------
@@ -166,6 +165,20 @@ class LinearBoostClassifier(AdaBoostClassifier):
     Notes
     -----
     The classifier only supports binary classification tasks.
+
+    Examples
+    --------
+    >>> from linearboost import LinearBoostClassifier
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> X, y = load_breast_cancer(return_X_y=True)
+    >>> clf = LinearBoostClassifier().fit(X, y)
+    >>> clf.predict(X[:2, :])
+    array([0, 0])
+    >>> clf.predict_proba(X[:2, :])
+    array([[0.88079708, 0.11920292],
+           [0.88079708, 0.11920292]])
+    >>> clf.score(X, y)
+    0.97...
     """
 
     _parameter_constraints: dict = {

--- a/src/linearboost/linear_boost.py
+++ b/src/linearboost/linear_boost.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 from sklearn.utils import compute_sample_weight
-from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils._param_validation import Interval, StrOptions, Hidden
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils.validation import check_is_fitted
 
@@ -68,6 +68,10 @@ class LinearBoostClassifier(AdaBoostClassifier):
         If 'SAMME.R' then use the SAMME.R real boosting algorithm.
         The SAMME.R algorithm typically converges faster than SAMME,
         achieving a lower test error with fewer boosting iterations.
+
+        .. deprecated:: sklearn 1.6
+            `algorithm` is deprecated and will be removed in sklearn 1.8. This
+            estimator only implements the 'SAMME' algorithm.
 
     scaler : str, default='minmax'
         Specifies the scaler to apply to the data. Options include:
@@ -156,7 +160,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
         Names of features seen during :term:`fit`. Defined only when `X`
         has feature names that are all strings.
 
-    scaler_ : TransformerMixin
+    scaler_ : transformer
         The scaler instance used to transform the data.
 
     Notes
@@ -167,7 +171,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
     _parameter_constraints: dict = {
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
-        "algorithm": [StrOptions({"SAMME", "SAMME.R"})],
+        "algorithm": [StrOptions({"SAMME", "SAMME.R"}), Hidden(StrOptions({"deprecated"}))],
         "scaler": [StrOptions({s for s in _scalers})],
         "class_weight": [
             StrOptions({"balanced_subsample", "balanced"}),
@@ -192,7 +196,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
             estimator=SEFR(),
             n_estimators=n_estimators,
             learning_rate=learning_rate,
-            algorithm=algorithm,
+            algorithm="deprecated" if SKLEARN_V1_6_OR_LATER else algorithm,
         )
 
         self.scaler = scaler
@@ -251,7 +255,7 @@ class LinearBoostClassifier(AdaBoostClassifier):
         self.n_classes_ = self.classes_.shape[0]
 
         if self.scaler not in _scalers:
-            raise ValueError(f"Invalid scaler; got {self.scaler}")
+            raise ValueError('Invalid scaler provided; got "%s".' % self.scaler)
 
         if self.scaler == "minmax":
             self.scaler_ = clone(_scalers["minmax"])

--- a/src/linearboost/sefr.py
+++ b/src/linearboost/sefr.py
@@ -57,9 +57,23 @@ class SEFR(LinearClassifierMixin, BaseEstimator):
     Notes
     -----
     The classifier only supports binary classification tasks.
+
+    Examples
+    --------
+    >>> from linearboost import SEFR
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> X, y = load_breast_cancer(return_X_y=True)
+    >>> clf = SEFR().fit(X, y)
+    >>> clf.predict(X[:2, :])
+    array([0, 0])
+    >>> clf.predict_proba(X[:2, :])
+    array([[1.00...e+000, 2.04...e-154],
+           [1.00...e+000, 1.63...e-165]])
+    >>> clf.score(X, y)
+    0.86...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "fit_intercept": ["boolean"],
     }
 

--- a/src/linearboost/sefr.py
+++ b/src/linearboost/sefr.py
@@ -56,7 +56,7 @@ class SEFR(LinearClassifierMixin, BaseEstimator):
 
     Notes
     -----
-    The classifier only supports binary classification tasks.
+    This classifier only supports binary classification tasks.
 
     Examples
     --------

--- a/uv.lock
+++ b/uv.lock
@@ -69,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "linearboost"
-version = "0.0.5"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "scikit-learn", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
- Removed deprecated `algorithm` parameter to ensure compatibility with Scikit-learn v1.6 and higher.
- Added usage examples to the docstrings of `SEFR` and `LinearBoostClassifier` classes for better clarity.
- Removed the `feature_importances_` attribute from the `LinearBoostClassifier` docstring, aligning with the base estimator behavior (`SEFR` doesn't expose this attribute, hence the same for `LinearBoostClassifier`).
- Minor enhancements in docs and typing.