### PR TITLE
Improve Scikit-learn compatibility and use `Self` type annotation in the return of `fit` methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 requires-python = ">=3.8,<3.14"
 dependencies = [
     "scikit-learn>=1.2.2",
+    "typing-extensions>=4.1.0; python_full_version < '3.11'"
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scikit-learn>=1.2.2
+typing-extensions>=4.1.0; python_version < "3.11"

--- a/src/linearboost/sefr.py
+++ b/src/linearboost/sefr.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.linear_model._base import LinearClassifierMixin
@@ -139,7 +146,7 @@ class SEFR(LinearClassifierMixin, BaseEstimator):
         return X, y
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y, sample_weight=None) -> "SEFR":
+    def fit(self, X, y, sample_weight=None) -> Self:
         """
         Fit the model according to the given training data.
 

--- a/uv.lock
+++ b/uv.lock
@@ -74,6 +74,7 @@ source = { editable = "." }
 dependencies = [
     { name = "scikit-learn", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -85,7 +86,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "scikit-learn", specifier = ">=1.2.2" }]
+requires-dist = [
+    { name = "scikit-learn", specifier = ">=1.2.2" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -574,4 +578,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/b00a62db91a83fff600de219b6ea9908e6918664899a2d85db222f4fbf19/typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b", size = 106520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/86/39b65d676ec5732de17b7e3c476e45bb80ec64eb50737a8dce1a4178aba1/typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5", size = 45683 },
 ]


### PR DESCRIPTION
* Add `typing-extensions` dependency for Python < 3.11 to support the `Self` type annotation
* Replace string type hints with proper `Self` return type annotations in the `fit` methods of `SEFR` and `LinearBoostClassifier` classes
* Update documentation to clarify scikit-learn version compatibility (1.4, 1.6+)
* Add warning filtering for scikit-learn 1.6+ deprecation notices for the `algorithm` parameter
* Fix parameter constraints for `algorithm` based on scikit-learn version
* Improve docstring formatting and accuracy for better API documentation
